### PR TITLE
Add error catch

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ If you are a developer, please you can also join our [Slack workspace](https://s
 3. Begin selling!
 
 ## Documentation
-* [Paystack Documentation](https://developers.paystack.co/v1.0/docs/)
+* [Paystack Documentation](https://developers.paystack.co/v2.0/docs/)
 * [Paystack Helpdesk](https://paystack.com/help)
 
 ## Support
 This repository is not suitable for general Paystack support. Please use the issue tracker for bug reports and feature requests directly related to this plugin. For general support, you can reach out by 
 
 * sending a message from [our website](https://paystack.com/contact).
-* posting a question on the plugin support forum.
+* posting a question on [the plugin support forum](https://wordpress.org/support/plugin/paystack-gateway-paid-memberships-pro).
 
 ## Contributing to Paystack Gateway for Paid Membership Pro
 If you have a patch or have stumbled upon an issue with the Paystack Gateway for Paid Membership Pro plugin, you can contribute this back to the code. Please read our [contributor guidelines](https://github.com/PaystackHQ/wordpress-paid-membership-pro-paystack/blob/master/.github/CONTRIBUTING.md) for more information how you can do this.

--- a/class.pmprogateway_paystack.php
+++ b/class.pmprogateway_paystack.php
@@ -3,7 +3,7 @@
  * Plugin Name: Paystack Gateway for Paid Memberships Pro
  * Plugin URI: https://paystack.com
  * Description: Plugin to add Paystack payment gateway into Paid Memberships Pro
- * Version: 1.4
+ * Version: 1.4.1
  * Author: Paystack
  * License: GPLv2 or later
  */
@@ -359,9 +359,15 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
                     // print_r($request);
                     if (!is_wp_error($request)) {
                         $paystack_response = json_decode(wp_remote_retrieve_body($request));
-                        $url = $paystack_response->data->authorization_url;
-                        wp_redirect($url);
-                        exit;
+                        if ($paystack_response->status){
+                            $url = $paystack_response->data->authorization_url;
+                            wp_redirect($url);
+                            exit;
+                        } else {
+                            $order->Gateway->delete($order);
+                            wp_redirect(pmpro_url("checkout", "?level=" . $order->membership_level->id . "&error=" . $paystack_response->message));
+                            exit();
+                        }
                     } else {
                         $order->Gateway->delete($order);
                         wp_redirect(pmpro_url("checkout", "?level=" . $order->membership_level->id . "&error=Failed"));

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://paystack.com/demo
 Tags: paystack, recurrent payments, nigeria, mastercard, visa, target, Naira, payments, verve, paid membership pro
 Requires at least: 3.1
 Tested up to: 4.9
-Stable tag: 1.0
+Stable tag: 1.4.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -71,7 +71,7 @@ You can find help and information on Paystack on our [Help Desk](https://paystac
  
 = Where can I get support or talk to other users? =
  
-If you get stuck, you can ask for help in the [Paystack Gateway for Paid Membership Pro Plugin Forum](https://wordpress.org/support/plugin/paid-paystack-gateway). You can also directly email support@paystack.com for assistance.
+If you get stuck, you can ask for help in the [Paystack Gateway for Paid Membership Pro Plugin Forum](https://wordpress.org/support/plugin/paystack-gateway-paid-memberships-pro). You can also directly email support@paystack.com for assistance.
  
 = Paystack Gateway for Paid Membership Pro is awesome! Can I contribute? =
 


### PR DESCRIPTION
When transaction initialization fails on an API level due to
wrong currency amount, invalid keys, etc, show output to user.

This was previously failing silently by showing a blank page.