### PR TITLE
Fix #11: Extra fields from register helper are not saved.

### DIFF
--- a/class.pmprogateway_paystack.php
+++ b/class.pmprogateway_paystack.php
@@ -15,7 +15,7 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
 
     DEFINE('KKD_PAYSTACKPMP', "paystack-paidmembershipspro");
 
-    function Paystack_Pmp_Gateway_load() 
+    function Paystack_Pmp_Gateway_load()
     {
         // paid memberships pro required
         if (!class_exists('PMProGateway')) {
@@ -49,11 +49,11 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
                 /**
                  * Run on WP init
                  */
-                static function init() 
+                static function init()
                 {
                     //make sure Paystack is a gateway option
                     add_filter('pmpro_gateways', array('PMProGateway_Paystack', 'pmpro_gateways'));
-                    
+
                     //add fields to payment settings
                     add_filter('pmpro_payment_options', array('PMProGateway_Paystack', 'pmpro_payment_options'));
                     add_filter('pmpro_payment_option_fields', array('PMProGateway_Paystack', 'pmpro_payment_option_fields'), 10, 2);
@@ -66,7 +66,7 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
                         add_filter('pmpro_required_billing_fields', array('PMProGateway_Paystack', 'pmpro_required_billing_fields'));
                         add_filter('pmpro_include_payment_information_fields', '__return_false');
                         add_filter('pmpro_checkout_before_change_membership_level', array('PMProGateway_Paystack', 'pmpro_checkout_before_change_membership_level'), 10, 2);
-                        
+
                         add_filter('pmpro_gateways_with_pending_status', array('PMProGateway_Paystack', 'pmpro_gateways_with_pending_status'));
                         add_filter('pmpro_pages_shortcode_checkout', array('PMProGateway_Paystack', 'pmpro_pages_shortcode_checkout'), 20, 1);
                         add_filter('pmpro_checkout_default_submit_button', array('PMProGateway_Paystack', 'pmpro_checkout_default_submit_button'));
@@ -78,7 +78,7 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
                 /**
                  * Redirect Settings to PMPro settings
                  */
-                static function plugin_action_links($links, $file) 
+                static function plugin_action_links($links, $file)
                 {
                     static $this_plugin;
 
@@ -96,29 +96,29 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
                 static function pmpro_checkout_default_submit_button($show)
                 {
                     global $gateway, $pmpro_requirebilling;
-                    
+
                     //show our submit buttons
                     ?>
                     <span id="pmpro_submit_span">
-                    <input type="hidden" name="submit-checkout" value="1" />		
-                    <input type="submit" class="pmpro_btn pmpro_btn-submit-checkout" value="<?php if ($pmpro_requirebilling) { _e('Check Out with Paystack', 'pmpro'); } else { _e('Submit and Confirm', 'pmpro');}?> &raquo;" />		
+                    <input type="hidden" name="submit-checkout" value="1" />
+                    <input type="submit" class="pmpro_btn pmpro_btn-submit-checkout" value="<?php if ($pmpro_requirebilling) { _e('Check Out with Paystack', 'pmpro'); } else { _e('Submit and Confirm', 'pmpro');}?> &raquo;" />
                     </span>
                     <?php
-                
+
                     //don't show the default
                     return false;
                 }
                 /**
                  * Make sure Paystack is in the gateways list
                  */
-                static function pmpro_gateways($gateways) 
+                static function pmpro_gateways($gateways)
                 {
                     if (empty($gateways['paystack'])) {
                         $gateways = array_slice($gateways, 0, 1) + array("paystack" => __('Paystack', KKD_PAYSTACKPMP)) + array_slice($gateways, 1);
                     }
                     return $gateways;
                 }
-                function kkd_pmpro_paystack_ipn() 
+                function kkd_pmpro_paystack_ipn()
                 {
                     global $wpdb;
                     // if ((strtoupper($_SERVER['REQUEST_METHOD']) != 'POST' ) || !array_key_exists('HTTP_X_PAYSTACK_SIGNATURE', $_SERVER) ) {
@@ -146,7 +146,7 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
                         $mode = pmpro_getOption("gateway_environment");
                         if ($mode == 'sandbox') {
                             $pk = pmpro_getOption("paystack_tpk");
-                        } else {    
+                        } else {
                             $pk = pmpro_getOption("paystack_lpk");
                         }
                         $pstk_logger = new pmpro_paystack_plugin_tracker('pm-pro',$pk);
@@ -156,7 +156,7 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
                         self::renewpayment($event);
                     case 'invoice.update':
                         self::renewpayment($event);
-                        
+
                         break;
                     }
                     http_response_code(200);
@@ -166,7 +166,7 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
                 /**
                  * Get a list of payment options that the Paystack gateway needs/supports.
                  */
-                static function getGatewayOptions() 
+                static function getGatewayOptions()
                 {
                     $options = array (
                         'paystack_tsk',
@@ -185,7 +185,7 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
                 /**
                  * Set payment options for payment settings page.
                  */
-                static function pmpro_payment_options($options) 
+                static function pmpro_payment_options($options)
                 {
                     //get Paystack options
                     $paystack_options = self::getGatewayOptions();
@@ -199,7 +199,7 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
                 /**
                  * Display fields for Paystack options.
                  */
-                static function pmpro_payment_option_fields($values, $gateway) 
+                static function pmpro_payment_option_fields($values, $gateway)
                 {
                     ?>
                     <tr class="pmpro_settings_divider gateway gateway_paystack" <?php if($gateway != "paystack") { ?>style="display: none;"<?php } ?>>
@@ -213,9 +213,9 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
                         </th>
                         <td>
                             <p><?php _e('To fully integrate with Paystack, be sure to use the following for your Webhook URL', 'pmpro');?> <pre><?php echo admin_url("admin-ajax.php") . "?action=kkd_pmpro_paystack_ipn";?></pre></p>
-                            
+
                         </td>
-                    </tr>		
+                    </tr>
                     <tr class="gateway gateway_paystack" <?php if($gateway != "paystack") { ?>style="display: none;"<?php } ?>>
                         <th scope="row" valign="top">
                             <label for="paystack_tsk"><?php _e('Test Secret Key', 'pmpro');?>:</label>
@@ -248,7 +248,7 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
                             <input type="text" id="paystack_lpk" name="paystack_lpk" size="60" value="<?php echo esc_attr($values['paystack_lpk'])?>" />
                         </td>
                     </tr>
-                    
+
                     <?php
                 }
 
@@ -294,14 +294,14 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
                 static function pmpro_checkout_before_change_membership_level($user_id, $morder)
                 {
                     global $wpdb, $discount_code_id;
-                    
+
                     //if no order, no need to pay
                     if (empty($morder)) {
                         return;
                     }
                     if (empty($morder->code))
                         $morder->code = $morder->getRandomCode();
-                        
+
                     $morder->payment_type = "paystack";
                     $morder->status = "pending";
                     $morder->user_id = $user_id;
@@ -314,16 +314,17 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
                     $morder->Gateway->sendToPaystack($morder);
                 }
 
-                function sendToPaystack(&$order) 
+                function sendToPaystack(&$order)
                 {
                     global $wp;
 
-                    
+                    do_action("pmpro_paypalexpress_session_vars");
+
                     $params = array();
                     $amount = $order->PaymentAmount;
                     $amount_tax = $order->getTaxForPrice($amount);
                     $amount = round((float)$amount + (float)$amount_tax, 2);
-            
+
                     //call directkit to get Webkit Token
                     $amount = floatval($order->InitialPayment);
 
@@ -344,7 +345,7 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
 
                     $koboamount = $amount*100;
                     $currency = pmpro_getOption("currency");
-                    
+
                     $paystack_url = 'https://api.paystack.co/transaction/initialize';
                     $headers = array(
                         'Content-Type'  => 'application/json',
@@ -392,7 +393,7 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
                     }
                     exit;
                 }
-                static function renewpayment($event) 
+                static function renewpayment($event)
                 {
                     global $wp,$wpdb;
 
@@ -404,15 +405,15 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
                         $email = $event->data->customer->email;
                         $old_order->getLastMemberOrderBySubscriptionTransactionID($subscription_code);
 
-                        if (empty($old_order)) { 
+                        if (empty($old_order)) {
                             exit();
                         }
                         $user_id = $old_order->user_id;
                         $user = get_userdata($user_id);
                         $user->membership_level = pmpro_getMembershipLevelForUser($user_id);
 
-                        if (empty($user)) { 
-                            exit(); 
+                        if (empty($user)) {
+                            exit();
                         }
 
                         $morder = new MemberOrder();
@@ -430,9 +431,9 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
                         $pmpro_level = $wpdb->get_row("SELECT * FROM $wpdb->pmpro_membership_levels WHERE id = '" . (int)$morder->membership_id . "' LIMIT 1");
                         $pmpro_level = apply_filters("pmpro_checkout_level", $pmpro_level);
                         $startdate = apply_filters("pmpro_checkout_start_date", "'" . current_time("mysql") . "'", $morder->user_id, $pmpro_level);
-                        
+
                         $enddate = "'" . date("Y-m-d", strtotime("+ " . $pmpro_level->expiration_number . " " . $pmpro_level->expiration_period, current_time("timestamp"))) . "'";
-                        
+
                         $custom_level = array(
                             'user_id'           => $morder->user_id,
                             'membership_id'     => $pmpro_level->id,
@@ -447,22 +448,22 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
                             'startdate'         => $startdate,
                             'enddate'           => $enddate
                         );
-                        
+
                         //get CC info that is on file
                         $morder->expirationmonth = get_user_meta($user_id, "pmpro_ExpirationMonth", true);
                         $morder->expirationyear = get_user_meta($user_id, "pmpro_ExpirationYear", true);
                         $morder->ExpirationDate = $morder->expirationmonth . $morder->expirationyear;
                         $morder->ExpirationDate_YdashM = $morder->expirationyear . "-" . $morder->expirationmonth;
 
-                        
+
                         //save
                         if ($morder->status != 'success') {
-                            
+
                             if (pmpro_changeMembershipLevel($custom_level, $morder->user_id, 'changed')) {
                                 $morder->status = "success";
                                 $morder->saveOrder();
                             }
-                                
+
                         }
                         $morder->getMemberOrderByID($morder->id);
 
@@ -476,14 +477,14 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
 
                 }
 
-                static function pmpro_pages_shortcode_checkout($content) 
+                static function pmpro_pages_shortcode_checkout($content)
                 {
                     $morder = new MemberOrder();
                     $found = $morder->getLastMemberOrder(get_current_user_id(), apply_filters("pmpro_confirmation_order_status", array("pending")));
                     if ($found) {
                         $morder->Gateway->delete($morder);
                     }
-                    
+
                     if (isset($_REQUEST['error'])) {
                         global $pmpro_msg, $pmpro_msgt;
 
@@ -508,21 +509,21 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
                     if ($reference != null) {
                         $_REQUEST['trxref'] = $reference;
                     }
-                    
+
                     if (empty($pmpro_invoice)) {
                         $morder =  new MemberOrder($_REQUEST['trxref']);
                         // $morder = new MemberOrder();
                         // $morder->getLastMemberOrder(get_current_user_id(), apply_filters("pmpro_confirmation_order_status", array("pending", "success")));
                         if (!empty($morder) && $morder->gateway == "paystack") $pmpro_invoice = $morder;
                     }
-                        
+
                     if (!empty($pmpro_invoice) && $pmpro_invoice->gateway == "paystack" && isset($pmpro_invoice->total) && $pmpro_invoice->total > 0) {
                             $morder = $pmpro_invoice;
                         if ($morder->code == $_REQUEST['trxref']) {
                             $pmpro_level = $wpdb->get_row("SELECT * FROM $wpdb->pmpro_membership_levels WHERE id = '" . (int)$morder->membership_id . "' LIMIT 1");
                             $pmpro_level = apply_filters("pmpro_checkout_level", $pmpro_level);
                             $startdate = apply_filters("pmpro_checkout_start_date", "'" . current_time("mysql") . "'", $morder->user_id, $pmpro_level);
-                                    
+
                             $mode = pmpro_getOption("gateway_environment");
                             if ($mode == 'sandbox') {
                                 $key = pmpro_getOption("paystack_tsk");
@@ -544,11 +545,11 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
                                 $paystack_response = json_decode(wp_remote_retrieve_body($request));
                                 if ('success' == $paystack_response->data->status && $pmpro_level->initial_payment ==  ($paystack_response->data->amount/100)) {
                                     $customer_code = $paystack_response->data->customer->customer_code;
-                                    
+
                                     //Add logger here
                                     $pstk_logger = new pmpro_paystack_plugin_tracker('pm-pro',$pk);
                                     $pstk_logger->log_transaction_success($_REQUEST['trxref']);
-
+									do_action('pmpro_after_checkout', $morder->user_id, $morder);
                                     //--------------------------------------------------
                                     if (strlen($order->subscription_transaction_id) > 3) {
                                         $enddate = "'" . date("Y-m-d", strtotime("+ " . $order->subscription_transaction_id, current_time("timestamp"))) . "'";
@@ -594,7 +595,7 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
                                             if ($response->meta->total >= 1) {
                                                 $plan = $response->data[0];
                                                 $plancode = $plan->plan_code;
-                                                
+
                                             } else {
                                                 //Create Plan
                                                 $body = array(
@@ -633,14 +634,14 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
                                             $token = $paystack_response->data->email_token;
                                             $morder->subscription_transaction_id = $subscription_code;
                                             $morder->subscription_token = $token;
-            
-                                            
+
+
                                         }
-                                        
+
                                     }
-                                    // 
+                                    //
                                     // die();
-                                    
+
                                     $custom_level = array(
                                             'user_id'           => $morder->user_id,
                                             'membership_id'     => $pmpro_level->id,
@@ -656,14 +657,14 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
                                             'enddate'           => $enddate
                                         );
                                     if ($morder->status != 'success') {
-                                        
+
                                         if (pmpro_changeMembershipLevel($custom_level, $morder->user_id, 'changed')) {
                                             $morder->membership_id = $pmpro_level->id;
                                             $morder->payment_transaction_id = $_REQUEST['trxref'];
                                             $morder->status = "success";
                                             $morder->saveOrder();
                                         }
-                                            
+
                                     }
                                     // echo "<pre>";
                                     // print_r($morder);
@@ -681,7 +682,7 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
                                         $current_user->membership_level = pmpro_getMembershipLevelForUser($current_user->ID);
                                         // echo "interesting";
                                     }
-                                    
+
                                     //send email to member
                                     $pmproemail = new PMProEmail();
                                     $pmproemail->sendCheckoutEmail($current_user, $invoice);
@@ -703,29 +704,29 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
                                     } else {
                                         include PMPRO_DIR . "/pages/confirmation.php";
                                     }
-                                    
+
                                     $content .= ob_get_contents();
                                     ob_end_clean();
                                 } else {
                                     $content = 'Invalid Reference';
-                                    
+
                                 }
 
                             } else {
                                     $content = 'Unable to Verify Transaction';
 
                             }
-                            
+
                         } else {
                             $content = 'Invalid Transaction Reference';
                         }
                     }
-            
-            
+
+
                     return $content;
-                    
+
                 }
-                function cancel(&$order) 
+                function cancel(&$order)
                 {
 
                     //no matter what happens below, we're going to cancel the order in our system
@@ -751,7 +752,7 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
                         if (!is_wp_error($request) && 200 == wp_remote_retrieve_response_code($request)) {
                             $paystack_response = json_decode(wp_remote_retrieve_body($request));
                             if ('active' == $paystack_response->data->status && $code == $paystack_response->data->subscription_code && '1' == $paystack_response->status) {
-                                
+
                                 $paystack_url = 'https://api.paystack.co/subscription/disable';
                                 $headers = array(
                                     'Content-Type'  => 'application/json',
@@ -779,7 +780,7 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
                     global $wpdb;
                     $wpdb->query("DELETE FROM $wpdb->pmpro_membership_orders WHERE id = '" . $order->id . "'");
                 }
-                function delete(&$order) 
+                function delete(&$order)
                 {
                     //no matter what happens below, we're going to cancel the order in our system
                     $order->updateStatus("cancelled");


### PR DESCRIPTION
Fix #11 
- The variables need to be saved to session before making the request to
paystack
- On successful payment the variables should be fetched from session and
populated as meta
- This is achieved using two action defined in register helper
- We just had to call the action 'pmpro_paypalexpress_session_vars' before
paystack call to put the variables to session
- Then call action "pmpro_after_checkout" on successful payment to get the
session variable and put them to user meta.